### PR TITLE
Use a single MongoDB cursor to iterate the collection

### DIFF
--- a/src/main/java/com/kodcu/provider/MongoToElasticProvider.java
+++ b/src/main/java/com/kodcu/provider/MongoToElasticProvider.java
@@ -45,30 +45,28 @@ public class MongoToElasticProvider implements Provider {
 
         MongoCursor<Document> cursor = getCursor(skip);
         while(cursor.hasNext() && result.size() < limit) {
-          result.add(cursor.next());
+            result.add(cursor.next());
         }
         return result;
     }
 
-  /**
-   * Get the MongoDB cursor.
-   * TODO: Fetch server cursor in case of a restart.
-   */
+    /**
+     * Get the MongoDB cursor.
+     */
     private MongoCursor<Document> getCursor(int skip) {
         if (cursor == null && cursorId == 0) {
-          System.out.println("Creating cursor.");
-          Document query = Document.parse(config.getMongo().getQuery());
-          BasicDBObject sort = new BasicDBObject("$natural", -1);
+            Document query = Document.parse(config.getMongo().getQuery());
+            BasicDBObject sort = new BasicDBObject("$natural", -1);
 
-          FindIterable<Document> results = collection
-              .find(query)
-              .sort(sort)
-              .skip(skip)
-              .noCursorTimeout(true);
-          cursor = results.iterator();
+            FindIterable<Document> results = collection
+                .find(query)
+                .sort(sort)
+                .skip(skip)
+                .noCursorTimeout(true);
+            cursor = results.iterator();
 
-          // TODO: Persist cursor ID somewhere to allow restarts.
-          this.cursorId = cursor.getServerCursor().getId();
+            // TODO: Persist cursor ID somewhere to allow restarts.
+            this.cursorId = cursor.getServerCursor().getId();
         }
         else if (cursor == null && cursorId != 0) {
             // TODO: Lookup cursor ID for resume.

--- a/src/main/java/com/kodcu/provider/MongoToElasticProvider.java
+++ b/src/main/java/com/kodcu/provider/MongoToElasticProvider.java
@@ -1,14 +1,16 @@
 package com.kodcu.provider;
 
-import com.kodcu.config.YamlConfiguration;
-import com.mongodb.client.FindIterable;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoCursor;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.log4j.Logger;
 import org.bson.Document;
 
-import java.util.Arrays;
-import java.util.List;
+import com.kodcu.config.YamlConfiguration;
+import com.mongodb.BasicDBObject;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
 
 /**
  * Created by Hakan on 5/18/2015.
@@ -18,6 +20,8 @@ public class MongoToElasticProvider implements Provider {
     private final Logger logger = Logger.getLogger(MongoToElasticProvider.class);
     private final MongoCollection<Document> collection;
     private final YamlConfiguration config;
+    private MongoCursor<Document> cursor;
+    private long cursorId = 0;
 
     public MongoToElasticProvider(final MongoCollection<Document> collection, final YamlConfiguration config) {
         this.collection = collection;
@@ -36,12 +40,41 @@ public class MongoToElasticProvider implements Provider {
 
     @Override
     public List buildJSONContent(int skip, int limit) {
-        Document query = Document.parse(config.getMongo().getQuery());
-        FindIterable<Document> results = collection.find(query).skip(skip).limit(limit);
-        MongoCursor<Document> cursor = results.iterator();
-        return Arrays.asList(cursor);
+        ArrayList<Document> result = new ArrayList<>(limit);
+        result.ensureCapacity(limit);
+
+        MongoCursor<Document> cursor = getCursor(skip);
+        while(cursor.hasNext() && result.size() < limit) {
+          result.add(cursor.next());
+        }
+        return result;
+    }
+
+  /**
+   * Get the MongoDB cursor.
+   * TODO: Fetch server cursor in case of a restart.
+   */
+    private MongoCursor<Document> getCursor(int skip) {
+        if (cursor == null && cursorId == 0) {
+          System.out.println("Creating cursor.");
+          Document query = Document.parse(config.getMongo().getQuery());
+          BasicDBObject sort = new BasicDBObject("$natural", -1);
+
+          FindIterable<Document> results = collection
+              .find(query)
+              .sort(sort)
+              .skip(skip)
+              .noCursorTimeout(true);
+          cursor = results.iterator();
+
+          // TODO: Persist cursor ID somewhere to allow restarts.
+          this.cursorId = cursor.getServerCursor().getId();
+        }
+        else if (cursor == null && cursorId != 0) {
+            // TODO: Lookup cursor ID for resume.
+            // Open existing cursor in case of restart??
+        }
+
+        return cursor;
     }
 }
-
-
-


### PR DESCRIPTION
On my environment I noticed performance slowed down almost immediately after beginning a sync from Mongo -> ES. After 50 million documents and 17 hours I killed the job. With these changes I'm got to 50 million documents after 2 hours.

After the initial changes I had to change the elastic search bulk indexer to flush the indexes more frequently.

I was also thinking it might be possible to make the load resumable in case something interrupts the load. Since setting `noCursorTimeout(true)` keeps the cursor alive on the server, at this point I haven't figured out how to reconnect to the cursor though.
